### PR TITLE
Upgrade to spring-boot 3.0

### DIFF
--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -1,4 +1,4 @@
-name: "CI - JDK 11 Build"
+name: "CI - JDK 17 Build"
 
 on:
   push:
@@ -9,16 +9,16 @@ on:
 
 jobs:
   build-jdk11:
-    name: "JDK 11 Build"
+    name: "JDK 17 Build"
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Build
         run: mvn clean install
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-boot-api</artifactId>
-    <version>2.1.Alpha2-SNAPSHOT</version>
+    <version>3.0.Final-SNAPSHOT</version>
 
     <name>Spring Boot dependencies for Quarkus</name>
     <description>The minimum dependencies to reduce the footprint of Quarkus applications using the Spring Boot features</description>
@@ -41,7 +41,7 @@
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spring-boot.version>2.1.13.RELEASE</spring-boot.version>
+        <spring-boot.version>3.0.4</spring-boot.version>
     </properties>
 
     <packaging>pom</packaging>

--- a/quarkus-spring-boot-orm-api/pom.xml
+++ b/quarkus-spring-boot-orm-api/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-api</artifactId>
-        <version>2.1.Alpha2-SNAPSHOT</version>
+        <version>3.0.Final-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-boot-orm-api</artifactId>
     <description>The minimum dependencies to reduce the footprint of Quarkus applications using the Spring Boot ORM classes</description>
-    <version>2.1.Alpha2-SNAPSHOT</version>
+    <version>3.0.Final-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/quarkus-spring-boot-properties-api/pom.xml
+++ b/quarkus-spring-boot-properties-api/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <artifactId>quarkus-spring-boot-api</artifactId>
         <groupId>io.quarkus</groupId>
-        <version>2.1.Alpha2-SNAPSHOT</version>
+        <version>3.0.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-boot-properties-api</artifactId>
     <description>The minimum dependencies to reduce the footprint of Quarkus applications using the Spring Boot Properties classes</description>
-    <version>2.1.Alpha2-SNAPSHOT</version>
+    <version>3.0.Final-SNAPSHOT</version>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/32027

Note: Spring boot 3 uses Java 17 bytecode